### PR TITLE
add pkgconf into all dependencies command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ for the KMS backend:
 
 On a recent Debian/Ubuntu system you can get all the dependencies with:
 
- `$ sudo apt install meson libvulkan-dev libglm-dev libassimp-dev libxcb1-dev libxcb-icccm4-dev libwayland-dev wayland-protocols libdrm-dev libgbm-dev`
+ `$ sudo apt install pkgconf meson libvulkan-dev libglm-dev libassimp-dev libxcb1-dev libxcb-icccm4-dev libwayland-dev wayland-protocols libdrm-dev libgbm-dev`
 
 # Building and installing
 


### PR DESCRIPTION
Required (usually present when you develop, but on clear install, it's not)